### PR TITLE
Alter CenteredSprite getters and setters for Center to account for scale size.

### DIFF
--- a/MSTests/MSTests.cpp
+++ b/MSTests/MSTests.cpp
@@ -238,7 +238,76 @@ namespace MSTests
 			}
 		}
 
+		TEST_METHOD(SpriteResizeTest)
+		{
 
+			const int WINDOW_WIDTH = 800;
+			const int WINDOW_HEIGHT = 600;
+			RenderWindow window(VideoMode(WINDOW_WIDTH, WINDOW_HEIGHT), "Sprite Resize Bounce");
+			World world(Vector2f(0, 1));
+
+			Texture texture;
+			Assert::IsTrue(texture.loadFromFile("../../smiley.png"));
+
+			auto createShape = [&world, &texture](PhysicsSprite& sprite, float size, Vector2f center)
+				{
+					sprite.setTexture(texture);
+					sprite.setSize({ size, size });
+					sprite.setCenter(center);
+					world.AddPhysicsBody(sprite);
+				};
+
+
+			PhysicsShapeList<PhysicsSprite> list;
+			const int COUNT = 3;
+			float spacing = WINDOW_WIDTH / COUNT;
+			float half_space = spacing / 2.0f;
+			for (int i = 0; i < COUNT; i++)
+			{
+				PhysicsSprite& sprite = list.Create();
+				float x = spacing * i + half_space;
+				createShape(sprite, (i + 1) * 50, {x, WINDOW_HEIGHT / 2.0f});
+			}
+
+			PhysicsRectangle floor;
+			floor.setSize(Vector2f(800, 20));
+			floor.setCenter(Vector2f(400, 590));
+			floor.setStatic(true);
+			world.AddPhysicsBody(floor);
+
+			Clock clock;
+			Time lastTime(clock.getElapsedTime());
+			Time runTime = clock.getElapsedTime() + sf::seconds(10);
+			while (clock.getElapsedTime() < runTime) {
+
+				// calculate MS since last frame
+				Time currentTime(clock.getElapsedTime());
+				Time deltaTime(currentTime - lastTime);
+				int deltaTimeMS(deltaTime.asMilliseconds());
+				if (deltaTimeMS > 0) {
+					world.UpdatePhysics(deltaTimeMS);
+					lastTime = currentTime;
+				}
+				window.clear(Color(0, 0, 0));
+
+				for (auto sprite : list)
+				{
+					window.draw(sprite);
+				}
+				window.draw(floor);
+				world.VisualizeAllBounds(window);
+				window.display();
+
+				Event ev;
+				if (window.pollEvent(ev))
+				{
+					if (ev.key.code == Keyboard::Space)
+					{
+						break;
+					}
+				}
+			}
+		}
 
 		TEST_METHOD(SFMLBinding)
 		{

--- a/MSTests/MSTests.vcxproj
+++ b/MSTests/MSTests.vcxproj
@@ -104,11 +104,11 @@
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <CustomBuildStep>
-      <Command>copy $(ProjectDir)arial.ttf $(OutputPath)</Command>
+      <Command>copy "$(ProjectDir)arial.ttf" "$(OutputPath)"</Command>
     </CustomBuildStep>
     <PostBuildEvent>
       <Message>copy font</Message>
-      <Command>copy $(ProjectDir)arial.ttf $(OutputPath)</Command>
+      <Command>copy "$(ProjectDir)arial.ttf" "$(OutputPath)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -183,9 +183,6 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\SFPhysics\SFPhysics.vcxproj">
       <Project>{5aae9625-7731-4380-a52c-e43ce8d02f99}</Project>
     </ProjectReference>
@@ -195,6 +192,9 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
       <FileType>Font</FileType>
     </Font>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/MSTests/MSTests.vcxproj.filters
+++ b/MSTests/MSTests.vcxproj.filters
@@ -28,11 +28,11 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Font Include="arial.ttf">
       <Filter>Resource Files</Filter>
     </Font>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/SFPhysics/CenteredSprite.cpp
+++ b/SFPhysics/CenteredSprite.cpp
@@ -27,15 +27,13 @@ Texture& sfp::CenteredSprite::getImage()
 
 void CenteredSprite::setCenter(Vector2f center)
 {
-    IntRect sz = getTextureRect();
-    setPosition(
-        Vector2f(center.x - (sz.width / 2), center.y - (sz.height / 2)));
+    Vector2f sz = getSize();
+    setPosition(Vector2f(center.x - (sz.x / 2), center.y - (sz.y / 2)));
 }
 
 Vector2f CenteredSprite::getCenter()
 {
-    IntRect sz = getTextureRect();
-    Vector2f szvect = Vector2f(sz.width, sz.height);
+    Vector2f szvect = getSize();
     Vector2f pos = getPosition();
     return Vector2f(pos + (szvect / 2.0f));
 }


### PR DESCRIPTION
When `CenteredSprite`s were resized, their true positions were not properly adjusted. This was due to the previous code only accounting for texture size and not its scale. To fix this, the relevant code now uses `getSize()`.

An MSTest, `SpriteResizeTest`, was also created to demonstrate the changes. It replicates the `Bounce` unit test but utilizes CenteredSprites of various sizes.

The following set of images shows a visual comparison of changes with bounding boxes rendered:
| Before | After |
| -- | -- |
| ![image](https://github.com/profK/SFPhysics/assets/35266349/ef55d074-a794-498e-ad1f-626725463ed5) | ![image](https://github.com/profK/SFPhysics/assets/35266349/e5ec6f5b-829d-4f3b-8d5c-fc387b7aa0ab) | 


This PR also modifies the Custom/Post-Build step of MSTest to account for spaces in the directory paths. You may feel free to remove those changes if you'd like.