### PR TITLE
Physics Layers & Fix PhysicsCircle setSize()

### DIFF
--- a/MSTests/MSTests.cpp
+++ b/MSTests/MSTests.cpp
@@ -309,6 +309,80 @@ namespace MSTests
 			}
 		}
 
+		/// <summary>
+		/// Spawns two balls and platforms, each on different layers. One of the balls cannot interact with one of the platforms.
+		/// </summary>
+		TEST_METHOD(LayerInteractionTest)
+		{
+			RenderWindow window(VideoMode(800, 600), "Set velocity test");
+			World world(Vector2f(0, 1));
+			PhysicsCircle circle1;
+			circle1.setCenter(Vector2f(300, 100));
+			circle1.setSize(Vector2f(50, 50));
+			circle1.setLayer(0);
+			circle1.setFillColor(sf::Color::White);
+			world.AddPhysicsBody(circle1);
+
+			PhysicsCircle circle2;
+			circle2.setCenter(Vector2f(500, 100));
+			circle2.setSize(Vector2f(50, 50));
+			circle2.setLayer(1);
+			circle2.setFillColor(sf::Color::Green);
+			world.AddPhysicsBody(circle2);
+
+
+			PhysicsRectangle floor1;
+			floor1.setSize(Vector2f(800, 20));
+			floor1.setCenter(Vector2f(400, 590));
+			floor1.setStatic(true);
+			floor1.setLayer(0);
+			world.AddPhysicsBody(floor1);
+
+			PhysicsRectangle floor2;
+			floor2.setSize(Vector2f(800, 20));
+			floor2.setCenter(Vector2f(400, 400));
+			floor2.setStatic(true);
+			floor2.setLayer(2);
+			floor2.setFillColor(sf::Color::Green);
+			world.AddPhysicsBody(floor2);
+
+			world.ExcludeCollision(1, 2);
+
+			system_clock::time_point last = system_clock::now();
+			
+			Clock clock;
+			Time lastTime(clock.getElapsedTime());
+			Time runTime = clock.getElapsedTime() + sf::seconds(10);
+			while (clock.getElapsedTime() < runTime) {
+
+				// calculate MS since last frame
+				Time currentTime(clock.getElapsedTime());
+				Time deltaTime(currentTime - lastTime);
+				int deltaTimeMS(deltaTime.asMilliseconds());
+				if (deltaTimeMS > 0) {
+					world.UpdatePhysics(deltaTimeMS, 1);
+					lastTime = currentTime;
+				}
+				window.clear(Color(0, 0, 0));
+
+				window.draw(circle1);
+				window.draw(circle2);
+				window.draw(floor1);
+				window.draw(floor2);
+				world.VisualizeAllBounds(window);
+				window.display();
+
+				Event ev;
+				if (window.pollEvent(ev))
+				{
+					if (ev.key.code == Keyboard::Space)
+					{
+						break;
+					}
+				}
+			}
+		}
+
 		TEST_METHOD(SFMLBinding)
 		{
 			World world(Vector2f(0, 1));

--- a/MSTests/MSTests.cpp
+++ b/MSTests/MSTests.cpp
@@ -320,12 +320,12 @@ namespace MSTests
 			circle1.setCenter(Vector2f(300, 100));
 			circle1.setSize(Vector2f(50, 50));
 			circle1.setLayer(0);
-			circle1.setFillColor(sf::Color::White);
+			circle1.setFillColor(sf::Color::Red);
 			world.AddPhysicsBody(circle1);
 
 			PhysicsCircle circle2;
 			circle2.setCenter(Vector2f(500, 100));
-			circle2.setSize(Vector2f(50, 50));
+			circle2.setSize(Vector2f(100, 100));
 			circle2.setLayer(1);
 			circle2.setFillColor(sf::Color::Green);
 			world.AddPhysicsBody(circle2);

--- a/SFPhysics/CircleBounds.cpp
+++ b/SFPhysics/CircleBounds.cpp
@@ -107,7 +107,7 @@ float sfp::CircleBounds::getRadius()
 
 void sfp::CircleBounds::setSize(Vector2f extents)
 {
-    setRadius(max(extents.x, extents.y)/2);
+    setRadius(max(extents.x, extents.y));
 }
 
 Vector2f sfp::CircleBounds::getSize()

--- a/SFPhysics/PhysicsBody.cpp
+++ b/SFPhysics/PhysicsBody.cpp
@@ -10,7 +10,7 @@ using namespace sfp;
 
 sfp::PhysicsBody::PhysicsBody():
 	restitution(1.0),mass(1.0),isStatic(false),
-	velocity(Vector2f(0,0))
+	velocity(Vector2f(0,0)), layer(0)
 {
 }
 
@@ -122,6 +122,16 @@ void sfp::PhysicsBody::setMoved(bool moved)
 bool sfp::PhysicsBody::hasMoved()
 {
 	return moved;
+}
+
+void sfp::PhysicsBody::setLayer(unsigned int layer)
+{
+	this->layer = layer;
+}
+
+unsigned int sfp::PhysicsBody::getLayer()
+{
+	return layer;
 }
 
 

--- a/SFPhysics/PhysicsLayer.cpp
+++ b/SFPhysics/PhysicsLayer.cpp
@@ -1,0 +1,2 @@
+#include "pch.h"
+#include "PhysicsLayer.h"

--- a/SFPhysics/SFPhysics.vcxproj
+++ b/SFPhysics/SFPhysics.vcxproj
@@ -181,6 +181,7 @@
     <ClInclude Include="include\SFPhysics\PhysicsBodyT.h" />
     <ClInclude Include="include\SFPhysics\PhysicsCircle.h" />
     <ClInclude Include="include\SFPhysics\PhysicsConvexPolygon.h" />
+    <ClInclude Include="include\SFPhysics\PhysicsLayer.h" />
     <ClInclude Include="include\SFPhysics\PhysicsRectangle.h" />
     <ClInclude Include="include\SFPhysics\PhysicsShape.h" />
     <ClInclude Include="include\SFPhysics\PhysicsShapeList.h" />
@@ -209,6 +210,7 @@
     <ClCompile Include="PhysicsBodyCollisionResult.cpp" />
     <ClCompile Include="PhysicsCircle.cpp" />
     <ClCompile Include="PhysicsConvexPolygon.cpp" />
+    <ClCompile Include="PhysicsLayer.cpp" />
     <ClCompile Include="PhysicsRectangle.cpp" />
     <ClCompile Include="PhysicsShape.cpp" />
     <ClCompile Include="PhysicsShapeList.cpp" />

--- a/SFPhysics/SFPhysics.vcxproj.filters
+++ b/SFPhysics/SFPhysics.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClInclude Include="include\SFPhysics\PhysicsConvexPolygon.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\SFPhysics\PhysicsLayer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SFPhysics.cpp">
@@ -150,6 +153,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="PhysicsShapeList.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PhysicsLayer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/SFPhysics/World.cpp
+++ b/SFPhysics/World.cpp
@@ -81,7 +81,7 @@ void sfp::World::UpdatePhysics(unsigned long deltaMilliseconds,unsigned long msP
 			// do collision, very stupid right now. long run should not check 
 			// objecst that havent moved
 			for (auto obj2 : objects) {
-				if ((obj != obj2) && (ignoreMovement || obj->hasMoved() || obj2->hasMoved())) {
+				if ((obj != obj2) && (ignoreMovement || obj->hasMoved() || obj2->hasMoved()) && HasCollision(obj->getLayer(), obj2->getLayer())) {
 					PhysicsBodyCollisionResult collision =
 						obj->collideWith(*obj2);
 					if (collision.hasCollided) {
@@ -110,4 +110,55 @@ void sfp::World::VisualizeAllBounds(RenderWindow& window)
 void sfp::World::setIgnoreMovement(bool  ignore)
 {
 	ignoreMovement = ignore;
+}
+
+void sfp::World::ExcludeCollision(unsigned int layer1, unsigned int layer2)
+{
+	// Use the lower layer number. This is to prevent overlap.
+	int primaryLayer = layer1 < layer2 ? layer1 : layer2;
+	int otherLayer = layer1 < layer2 ? layer2 : layer1;
+
+	for (auto layer : layers)
+	{
+		if (layer.Layer == primaryLayer)
+		{
+			layer.AddExcludedLayer(otherLayer);
+			return;
+		}
+	}
+
+	PhysicsLayer layer;
+	layer.Layer = layer1;
+	layer.AddExcludedLayer(layer2);
+	layers.push_back(layer);
+}
+
+void sfp::World::IncludeCollision(unsigned int layer1, unsigned int layer2)
+{
+	// Use the lower layer number. This is to prevent overlap.
+	int primaryLayer = layer1 < layer2 ? layer1 : layer2;
+	int otherLayer = layer1 < layer2 ? layer2 : layer1;
+
+	for (auto layer : layers)
+	{
+		if (layer.Layer == primaryLayer)
+		{
+			layer.RemoveExcludedLayer(otherLayer);
+			return;
+		}
+	}
+}
+
+bool sfp::World::HasCollision(unsigned int layer1, unsigned int layer2)
+{
+	// Use the lower layer number. This is to prevent overlap.
+	int primaryLayer = layer1 < layer2 ? layer1 : layer2;
+	int otherLayer = layer1 < layer2 ? layer2 : layer1;
+
+	for (auto layer : layers)
+	{
+		if (layer.Layer == primaryLayer)
+			return !layer.ExcludesLayer(otherLayer);
+	}
+	return true;
 }

--- a/SFPhysics/include/SFPhysics/PhysicsBody.h
+++ b/SFPhysics/include/SFPhysics/PhysicsBody.h
@@ -16,11 +16,11 @@ namespace sfp {
 		bool isStatic;
 		Vector2f velocity;
 		bool moved;
-	
+		unsigned int layer;
 	public:
 		PhysicsBody();
 		PhysicsBody(Bounds& bounds, bool isStatic = false,
-			float restitution=1.0f,float mass=1.0f);
+			float restitution=1.0f,float mass=1.0f, int layer = 0);
 		void applyImpulse(Vector2f impulse);
 		void update(unsigned int deltaMillisconds);
 		void setPosition(Vector2f center);
@@ -39,6 +39,16 @@ namespace sfp {
 		PhysicsBodyCollisionResult collideWith(PhysicsBody& other);
 		void setMoved(bool moved = false);
 		bool hasMoved();
+		/// <summary>
+		/// Sets the collision layer to be set to this object. Default is 0.
+		/// </summary>
+		/// <param name="layer">The layer to use.</param>
+		void setLayer(unsigned int layer);
+		/// <summary>
+		/// Gets the current layer associated with this object. Default is 0.
+		/// </summary>
+		/// <returns>The layer this object is associated with.</returns>
+		unsigned int getLayer();
 
 		bool operator == (const PhysicsBody& other) {
 			return this == &other;

--- a/SFPhysics/include/SFPhysics/PhysicsLayer.h
+++ b/SFPhysics/include/SFPhysics/PhysicsLayer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <list>
+
+/// <summary>
+/// Struct that stores a Layer and a list of Exclusion layers.
+/// This struct is intended for internal use.
+/// 
+/// Notes: This isn't intended to be a very complex Physics Layer system. Instead, it tries to prioritize ease-of-use without concerning too much on bit flags.
+/// </summary>
+struct PhysicsLayer
+{
+public:
+    unsigned Layer;
+    std::list<unsigned> ExclusionLayers;
+
+    bool ExcludesLayer(unsigned layer)
+    {
+        for (unsigned excludedLayer : ExclusionLayers)
+        {
+            if (excludedLayer == layer)
+                return true;
+        }
+        return false;
+    }
+
+    void AddExcludedLayer(unsigned layer)
+    {
+        for (unsigned excludedLayer : ExclusionLayers)
+        {
+            if (excludedLayer == layer)
+                return;
+        }
+
+        ExclusionLayers.push_back(layer);
+    }
+
+    void RemoveExcludedLayer(unsigned layer)
+    {
+        ExclusionLayers.remove(layer);
+    }
+};
+

--- a/SFPhysics/include/SFPhysics/World.h
+++ b/SFPhysics/include/SFPhysics/World.h
@@ -2,6 +2,7 @@
 #include <SFML/Graphics.hpp>
 #include <list>
 #include "PhysicsBody.h"
+#include "PhysicsLayer.h"
 
 using namespace sf;
 using namespace std;
@@ -15,6 +16,7 @@ namespace sfp {
 		bool ignoreMovement;
 		list<PhysicsBody*> removalList;
 		long unsigned deltaAccumulator = 0;
+		list<PhysicsLayer> layers;
 	public:
 		World(Vector2f gravity);
 
@@ -23,6 +25,25 @@ namespace sfp {
 		void UpdatePhysics(unsigned long deltaMilliseconds, unsigned long msPerTick = 0);
 		void VisualizeAllBounds(RenderWindow& window);
 		void setIgnoreMovement(bool ignore = true);
+		/// <summary>
+		/// Prevents a layer from interacting with another layer.
+		/// </summary>
+		/// <param name="layer1">The first layer to compare</param>
+		/// <param name="layer2">The second layer to compare</param>
+		void ExcludeCollision(unsigned int layer1, unsigned int layer2);
+		/// <summary>
+		/// Allows a layer to interact with another layer. Note that layers can interact with other layers by default.
+		/// </summary>
+		/// <param name="layer1">The first layer to compare</param>
+		/// <param name="layer2">The second layer to compare</param>
+		void IncludeCollision(unsigned int layer1, unsigned int layer2);
+		/// <summary>
+		/// Check if a layer is allowed to collide with another layer.
+		/// </summary>
+		/// <param name="layer1">The first layer to compare</param>
+		/// <param name="layer2">The second layer to compare</param>
+		/// <returns></returns>
+		bool HasCollision(unsigned int layer1, unsigned int layer2);
 	};
 }
 


### PR DESCRIPTION
This is a two-part PR. One is a major implementation, while the other is a bug fix. I can split it into two on request.

This primarily does a very simple implementation of Physics Layers. The motivation for implementing this is to make it easier for projects that use this library to add complex collision, such as pickups & power-ups that can only interact with the player but not enemies.

It creates a struct, `PhysicsLayer`, that stores a list of excluded layers. All layers interact with each other by default.

Since it's a simple implementation, the code isn't optimized. The code allows for `std::list::max_size()` amount of layers, but I'm sure there will be slowdowns if you use too many objects and layers at the same time.

Usage should be easy to use: Call `PhysicsShape.setLayer(unsigned layer)` to set up an object's layer. To prevent a layer from interacting from another, use `World.ExcludeCollision(unsigned layer1, unsigned layer2)`. By default, all objects are on layer 0.

The created functions all have documentation on them, so it shouldn't be confusing to use.

An MSTest, `LayerInteractionTest`, was created to showcase this in action.

While writing this test, I discovered that the `PhysicsCircle` rendering and bounds were inconsistent when using `setSize()`. This is because the `PhysicsCircle` takes in a radius and passes it into `sf::CircleShape`, but divides it for the collision test in `CircleBounds`, which assumed that the parameter was a diameter instead. To fix, I removed the division.

See comparison & demonstration below. Green objects are on separate layers and are set so that they cannot interact with each other.
| Before | After |
| -- | -- |
| ![testhost_WsJu77taoY](https://github.com/user-attachments/assets/a1d6b164-12ef-4171-9d6e-1d4547162ab7) | ![testhost_9gg1XJfahK](https://github.com/user-attachments/assets/c8e2c0c4-045d-42be-bdfb-8882cc6c2844) |

